### PR TITLE
Stringifier: Support ArrayExpression multiline output

### DIFF
--- a/src-transpiler/Stringifier.mjs
+++ b/src-transpiler/Stringifier.mjs
@@ -638,9 +638,22 @@ class Stringifier {
    * @returns {string} Stringification of the node.
    */
   ArrayExpression(node) {
-    const {elements, extra} = node;
+    const {elements, extra, loc} = node;
     const e = !!extra?.trailingComma ? ',' : '';
-    return '[' + this.mapToSource(elements).join(', ') + e + ']';
+    const sameLine = loc.start.line === loc.end.line;
+    if (sameLine) {
+      return '[' + this.mapToSource(elements).join(', ') + e + ']';
+    }
+    let out = '[\n';
+    this.numSpaces++;
+    const {spaces} = this;
+    out += this.mapToSource(elements)
+      .map(_ => spaces + _)
+      .join(',\n');
+    this.numSpaces--;
+    out += e;
+    out += '\n' + this.spaces + ']';
+    return out;
   }
   /**
    * @param {import("@babel/types").VariableDeclaration} node - The Babel AST node.

--- a/test/typechecking/ArrayExpression-keep-layout-input.mjs
+++ b/test/typechecking/ArrayExpression-keep-layout-input.mjs
@@ -10,3 +10,17 @@ const b = [
 ];
 const c = [1, 2, 3];
 const d = [1, 2, 3,];
+if (true) {
+  const e = [
+    1,
+    2,
+    3
+  ];
+  const f = [
+    1,
+    2,
+    3,
+  ];
+  const g = [1, 2, 3];
+  const h = [1, 2, 3,];
+}

--- a/test/typechecking/ArrayExpression-keep-layout-output.mjs
+++ b/test/typechecking/ArrayExpression-keep-layout-output.mjs
@@ -10,3 +10,17 @@ const b = [
 ];
 const c = [1, 2, 3];
 const d = [1, 2, 3,];
+if (true) {
+  const e = [
+    1,
+    2,
+    3
+  ];
+  const f = [
+    1,
+    2,
+    3,
+  ];
+  const g = [1, 2, 3];
+  const h = [1, 2, 3,];
+}


### PR DESCRIPTION
To my surprise not even Babel is handling this: [Babel REPL](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBAhjAvDA2gKBjAjAGgzAJj0wGY0BdAbjVElgCMlV9d8j8S8qbxoZgmKXIRwwS3WnwAmg4UTE5uASwBmMABRQATgFcApgEoYAb3yTYewfkytMmdnbH5umczDXJ0j23Yd3OztSuvLAA5rKi8uJB_CEwABYRIgrcAL5oQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=&prettier=false&targets=&version=7.23.2&externalPlugins=&assumptions=%7B%7D)

Current output:

![image](https://github.com/kungfooman/RuntimeTypeInspector.js/assets/5236548/97b7cfd1-d7d2-438c-bb97-a3b2fe2cf2ed)


However, we are fine now:

![image](https://github.com/kungfooman/RuntimeTypeInspector.js/assets/5236548/58583d6c-4ef3-47b0-8133-833383c094d7)

Even trailing commas are respected :smirk: 