### PR TITLE
Generate types + update transpiler to @runtime-type-inspector/transpiler@2.0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+types

--- a/@runtime-type-inspector/transpiler/.gitignore
+++ b/@runtime-type-inspector/transpiler/.gitignore
@@ -1,3 +1,3 @@
 index.cjs
 index.mjs
-
+types.d.ts

--- a/@runtime-type-inspector/transpiler/package.json
+++ b/@runtime-type-inspector/transpiler/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@runtime-type-inspector/transpiler",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Validating JSDoc types at runtime for high-quality types - Trust is good, control is better.",
   "main": "./index.cjs",
   "module": "./index.mjs",
+  "types": "./types.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kungfooman/RuntimeTypeInspector.js.git"

--- a/@runtime-type-inspector/transpiler/package.json
+++ b/@runtime-type-inspector/transpiler/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "index.cjs",
-    "index.mjs"
+    "index.mjs",
+    "types.d.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "build": "rollup -c",
     "build:atBabelCore": "rollup -c --environment target:atBabelCore",
+    "build:dts": "tsc src-transpiler/index.mjs --outDir types/transpiler --allowJs --declaration --emitDeclarationOnly --target esnext",
+    "build:types": "npm run build:dts && rollup -c --environment target:types",
     "test": "node test.mjs",
     "test:update": "node gen_tests.mjs > test/typechecking.json",
     "lint": "eslint --ext .js,.mjs,.cjs src-transpiler",

--- a/plugin-rollup/README.md
+++ b/plugin-rollup/README.md
@@ -1,4 +1,4 @@
-Rollup plugin for `runtime-type-inspector`.
+Rollup plugin for `@runtime-type-inspector/transpiler`.
 
 Installation:
 
@@ -6,6 +6,8 @@ Installation:
 npm install @runtime-type-inspector/plugin-rollup
 ```
 
-Integration into your build script:
+Example of integration into your build script:
 
-- todo link to PlayCanvas example repo rollup.config.mjs
+- https://github.com/playcanvas/engine/pull/5817
+
+Have fun! If you run into any issues, please open an issue at https://github.com/kungfooman/RuntimeTypeInspector.js

--- a/plugin-rollup/index.mjs
+++ b/plugin-rollup/index.mjs
@@ -24,7 +24,7 @@ function getHeader(validateDivision) {
  * self-test Stringifier class to ensure its functionanlity.
  * @param {string[]} [options.ignoredFiles] - Ignore certain files which operate in a different
  * context, for example framework/parsers/draco-worker.js operates as WebWorker (without RTI).
- * @returns {import('rollup').Plugin}
+ * @returns {import('rollup').Plugin} The rollup plugin.
  */
 function runtimeTypeInspector({enable = true, selftest = false, ignoredFiles} = {}) {
   const filter = createFilter([

--- a/plugin-rollup/package-lock.json
+++ b/plugin-rollup/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@runtime-type-inspector/plugin-rollup",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@runtime-type-inspector/plugin-rollup",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@runtime-type-inspector/runtime": "^2.0.6",
-        "@runtime-type-inspector/transpiler": "^2.0.13",
+        "@runtime-type-inspector/transpiler": "^2.0.14",
         "rollup": "^3.29.4"
       }
     },
@@ -342,9 +342,9 @@
       "integrity": "sha512-TovIrltJwWlfCe5FxjHwNtPiuMshXgZWP8N/49hV6ay2SHE9UpYcodz5gkbX2zsAaFlI7733+eo+WZLe5cX4PQ=="
     },
     "node_modules/@runtime-type-inspector/transpiler": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/transpiler/-/transpiler-2.0.13.tgz",
-      "integrity": "sha512-XMSIADYZxOvmczIq4rdYypyNsYkaIWUbEpEPblq83FrfuYxCeE6BIGmT2NL+4WF2q1TTdBOoMzXUNwHOd1CmJg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/transpiler/-/transpiler-2.0.14.tgz",
+      "integrity": "sha512-rdXrtIVN1YCG1owIrEgnP7Lq08k6OXu5+51SBnVvxnUI4zJjomJwatFsAWQip5yQp6LgakVf27dML9Kt8q7Lbw==",
       "dependencies": {
         "@babel/core": "^7.2.0",
         "@runtime-type-inspector/runtime": "^2.0.5",
@@ -900,9 +900,9 @@
       "integrity": "sha512-TovIrltJwWlfCe5FxjHwNtPiuMshXgZWP8N/49hV6ay2SHE9UpYcodz5gkbX2zsAaFlI7733+eo+WZLe5cX4PQ=="
     },
     "@runtime-type-inspector/transpiler": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/transpiler/-/transpiler-2.0.13.tgz",
-      "integrity": "sha512-XMSIADYZxOvmczIq4rdYypyNsYkaIWUbEpEPblq83FrfuYxCeE6BIGmT2NL+4WF2q1TTdBOoMzXUNwHOd1CmJg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/transpiler/-/transpiler-2.0.14.tgz",
+      "integrity": "sha512-rdXrtIVN1YCG1owIrEgnP7Lq08k6OXu5+51SBnVvxnUI4zJjomJwatFsAWQip5yQp6LgakVf27dML9Kt8q7Lbw==",
       "requires": {
         "@babel/core": "^7.2.0",
         "@runtime-type-inspector/runtime": "^2.0.5",

--- a/plugin-rollup/package.json
+++ b/plugin-rollup/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@runtime-type-inspector/plugin-rollup",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.mjs",
   "type": "module",
+  "types": "types.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -11,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@runtime-type-inspector/runtime": "^2.0.6",
-    "@runtime-type-inspector/transpiler": "^2.0.13",
+    "@runtime-type-inspector/transpiler": "^2.0.14",
     "rollup": "^3.29.4"
   }
 }

--- a/plugin-rollup/types.d.ts
+++ b/plugin-rollup/types.d.ts
@@ -1,0 +1,8 @@
+// The content of this types.d.ts file is authored manually. 
+type Options = {
+  enable?: boolean;
+  selftest?: boolean;
+  ignoredFiles?: string[];
+};
+declare function runtimeTypeInspector(options?: Options): import('rollup').Plugin;
+export{runtimeTypeInspector};

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -153,10 +153,10 @@ function buildTarget(name, rootFile, path, buildType, moduleFormat) {
 }
 /** @type {RollupOptions} */
 const target_types = {
-  input: 'types/index.d.ts',
+  input: 'types/transpiler/index.d.mts',
   output: [{
-    file: 'build/runtime-type-inspector.d.ts',
-    footer: 'export as namespace rtiTranspiler;',
+    file: '@runtime-type-inspector/transpiler/types.d.ts',
+    //footer: 'export as namespace rtiTranspiler;',
     format: 'es'
   }],
   plugins: [


### PR DESCRIPTION
Fixes #24

The `types.d.ts` file could be a bit shorter/nicer by using:

https://github.com/playcanvas/engine/blob/main/utils/types-undollar.mjs

But it only has 10 of such cases, for example

```ts
type Stat = Stat$1;
```

(not a huge issue right now)