### PR TITLE
registerTypedef: prevent typedef-as-string overwrite if it already exists as object

### DIFF
--- a/src-runtime/registerTypedef.mjs
+++ b/src-runtime/registerTypedef.mjs
@@ -7,6 +7,11 @@ const typedefs = {};
  * @param {Record<string, object>} typedef - The parsed typedef from source.
  */
 function registerTypedef(name, typedef) {
+  // If it already exists as object but now it's a string
+  if (typeof typedefs[name] === 'object' && typeof typedef === 'string') {
+    // console.log("registerTypedef> ignore", name, typedef);
+    return;
+  }
   typedefs[name] = typedef;
 }
 export {typedefs, registerTypedef};

--- a/src-transpiler/parseJSDocTypedef.mjs
+++ b/src-transpiler/parseJSDocTypedef.mjs
@@ -55,7 +55,10 @@ function parseJSDocTypedef(typedefs, warn, comment, expandType) {
       // Drop description
       name = name.split(' ')[0];
       lastTypedef = expandType(def);
-      typedefs[name] = lastTypedef;
+      // Ignore @typedef's that only refer to themselves in another file (see typedef-overwrite test)
+      if (lastTypedef !== name) {
+        typedefs[name] = lastTypedef;
+      }
     } else if (line.startsWith('@property')) {
       // class @property
       if (!lastTypedef) {

--- a/test/typechecking/typedef-overwrite-input.mjs
+++ b/test/typechecking/typedef-overwrite-input.mjs
@@ -1,0 +1,8 @@
+/**
+ * @typedef {Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array} TypedArray
+ * @typedef {BigInt64Array | BigUint64Array} BigTypedArray
+ * @typedef {TypedArray | BigTypedArray} AnyTypedArray
+ */
+/**
+ * @typedef {import('./utils/maths.js').TypedArray} TypedArray
+ */

--- a/test/typechecking/typedef-overwrite-output.mjs
+++ b/test/typechecking/typedef-overwrite-output.mjs
@@ -1,0 +1,28 @@
+registerTypedef('TypedArray', {
+  "type": "union",
+  "members": [
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array"
+  ]
+});
+registerTypedef('BigTypedArray', {
+  "type": "union",
+  "members": [
+    "BigInt64Array",
+    "BigUint64Array"
+  ]
+});
+registerTypedef('AnyTypedArray', {
+  "type": "union",
+  "members": [
+    "TypedArray",
+    "BigTypedArray"
+  ]
+});


### PR DESCRIPTION
Fixes #52