### PR TITLE
Implement typeof expression in all three expand functions

### DIFF
--- a/src-transpiler/expandTypeBabelTS.mjs
+++ b/src-transpiler/expandTypeBabelTS.mjs
@@ -1,7 +1,6 @@
 import {parse} from '@babel/parser';
 /**
  * @todo Better handling of weird case: Array<>
- * @todo implement TypeQuery, e.g. for expandTypeBabelTS('typeof Number');
  * @example
  * const {expandTypeBabelTS} = await import("./src-transpiler/expandTypeBabelTS.mjs");
  * expandTypeBabelTS('[string, Array|AnyTypedArray, number[]]|[ONNXTensor]');
@@ -12,9 +11,9 @@ import {parse} from '@babel/parser';
  * expandTypeBabelTS('Array<"abc" | 123>       '); // Outputs: {type: 'array', elementType: {type: 'union', members: ['"abc"', '123']}}
  * expandTypeBabelTS('  (string ) |(number )   '); // Outputs: {type: 'union', members: [ 'string', 'number']}
  * expandTypeBabelTS(' "apples" | ( "bananas") '); // Outputs: {type: 'union', members: [ '"apples"', '"bananas"']}
- * expandTypeBabelTS('123?                     '); // Outputs: {"type":"union","members":["123","null"]}
- * expandTypeBabelTS('123|null                 '); // Outputs: {"type":"union","members":["123","null"]}
- * expandTypeBabelTS('Map<string, any>');
+ * expandTypeBabelTS('123?                     '); // Outputs: {type: 'union', members: ['123', 'null']}
+ * expandTypeBabelTS('123|null                 '); // Outputs: {type: 'union', members: ['123', 'null']}
+ * expandTypeBabelTS('Map<string, any>         '); // Outputs: {type: 'map', key: 'string', val: 'any'}
  * expandTypeBabelTS("(a: number, b: number) => number")
  * @param {string} type - The input type.
  * @returns {string|object|undefined} - See `toSourceBabelTS`.
@@ -200,6 +199,9 @@ function toSourceBabelTS(node) {
       return toSourceBabelTS(node.type);
     case 'LastTypeNode':
       return toSourceBabelTS(node.qualifier);
+    case 'TSTypeQuery':
+      const argument = toSourceBabelTS(node.exprName);
+      return {type: 'typeof', argument};
     default:
       console.warn('toSourceBabelTS> unhandled type', node.type, node);
       debugger;

--- a/src-transpiler/expandTypeDepFree.mjs
+++ b/src-transpiler/expandTypeDepFree.mjs
@@ -10,13 +10,14 @@
  */
 /**
  * @typedef {object} ExpandTypeReturnValue
- * @property {'array' | 'union' | 'record' | 'tuple' | 'object' | 'promise'} type - The type.
+ * @property {'array' | 'union' | 'record' | 'tuple' | 'object' | 'promise' | 'typeof'} type - The type.
  * @property {object | string} [elementType] - For Array.
  * @property {object | string} [key] - For Record<key, val>
  * @property {object | string} [val] - For Record<key, val>
  * @property {(object | string)[]} [members] - For unions.
  * @property {object | string} [properties] - For objects.
  * @property {(object | string)[]} [elements] - For tuples.
+ * @property {object | string} [argument] - For typeof.
  */
 /**
  * 'DepFree' refers to the fact that this function has no dependencies,
@@ -113,6 +114,11 @@ function expandTypeDepFree(type) {
       type: 'tuple',
       elements: elements.map(expandTypeDepFree)
     };
+  }
+  // (8) expand typeof expressions
+  if (type.startsWith('typeof ')) {
+    const argument = expandTypeDepFree(type.substring(7));
+    return {type: 'typeof', argument};
   }
   if (type === 'object' || type === 'Object') {
     return {


### PR DESCRIPTION
Fixes: #71

Output of `typeof Number` via REPL/expandType is now:

```js
// expandTypeTS:
{
  "type": "typeof",
  "argument": "Number"
}
// expandTypeBabelTS:
{
  "type": "typeof",
  "argument": "Number"
}
// expandTypeDepFree:
{
  "type": "typeof",
  "argument": "Number"
}
```