### PR TITLE
Implement TypeOperator (keyof)

### DIFF
--- a/src-transpiler/expandType.mjs
+++ b/src-transpiler/expandType.mjs
@@ -74,6 +74,8 @@ function toSourceTS(node) {
     UnionType, JSDocNullableType, TrueKeyword, FalseKeyword, VoidKeyword, UnknownKeyword,
     NeverKeyword, BigIntKeyword, BigIntLiteral, ConditionalType, IndexedAccessType, RestType,
     TypeQuery,       // parseType('typeof Number')
+    TypeOperator,    // parseType('keyof typeof obj')
+    KeyOfKeyword, // "operator" key in TypeOperator node
     ConstructorType, // parseType('new (...args: any[]) => any');
   } = ts.SyntaxKind;
   // console.log({typeArguments, typeName, kind_, node});
@@ -123,6 +125,12 @@ function toSourceTS(node) {
     case TypeQuery:
       const argument = toSourceTS(node.exprName);
       return {type: 'typeof', argument};
+    case TypeOperator:
+      if (node.operator === KeyOfKeyword) {
+        const argument = toSourceTS(node.type);
+        return {type: 'keyof', argument};
+      }
+      console.warn("unimplemented TypeOperator", node);
     case TypeReference: {
       if ((typeName.text === 'Object' || typeName.text === 'Record') && typeArguments?.length === 2) {
         return {

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -64,6 +64,10 @@
     "output": "./test/typechecking/good-old-es5-output.mjs"
   },
   {
+    "input": "./test/typechecking/keyof-typeof-input.mjs",
+    "output": "./test/typechecking/keyof-typeof-output.mjs"
+  },
+  {
     "input": "./test/typechecking/simple-ObjectMethod-computed-input.mjs",
     "output": "./test/typechecking/simple-ObjectMethod-computed-output.mjs"
   },

--- a/test/typechecking/keyof-typeof-input.mjs
+++ b/test/typechecking/keyof-typeof-input.mjs
@@ -1,0 +1,22 @@
+/** @todo keep in one line */
+const obj = {a: 1, b: 2, c: 3};
+/**
+ * @typedef {keyof typeof obj} ObjKey - Will be: "a" | "b" | "c"
+ */
+const DataTypeMap = Object.freeze({
+  float32: Float32Array,
+  float64: Float64Array,
+  string: Array,
+  int8: Int8Array,
+  uint8: Uint8Array,
+  int16: Int16Array,
+  uint16: Uint16Array,
+  int32: Int32Array,
+  uint32: Uint32Array,
+  int64: BigInt64Array,
+  uint64: BigUint64Array,
+  bool: Uint8Array,
+});
+/**
+ * @typedef {keyof typeof DataTypeMap} DataType
+ */

--- a/test/typechecking/keyof-typeof-output.mjs
+++ b/test/typechecking/keyof-typeof-output.mjs
@@ -1,0 +1,40 @@
+registerTypedef('ObjKey', {
+  "type": "keyof",
+  "argument": {
+    "type": "typeof",
+    "argument": "obj"
+  }
+});
+registerTypedef('DataType', {
+  "type": "keyof",
+  "argument": {
+    "type": "typeof",
+    "argument": "DataTypeMap"
+  }
+});
+/** @todo keep in one line */
+const obj = {
+  a: 1,
+  b: 2,
+  c: 3
+};
+/**
+ * @typedef {keyof typeof obj} ObjKey - Will be: "a" | "b" | "c"
+ */
+const DataTypeMap = Object.freeze({
+  float32: Float32Array,
+  float64: Float64Array,
+  string: Array,
+  int8: Int8Array,
+  uint8: Uint8Array,
+  int16: Int16Array,
+  uint16: Uint16Array,
+  int32: Int32Array,
+  uint32: Uint32Array,
+  int64: BigInt64Array,
+  uint64: BigUint64Array,
+  bool: Uint8Array,
+});
+/**
+ * @typedef {keyof typeof DataTypeMap} DataType
+ */


### PR DESCRIPTION
Fixes: #85

In further PR's I still need to add `keyof` validation, but first we have to parse it and establish some structure to rely upon (plus unit tests etc.).