### PR TITLE
Implement named tuples

### DIFF
--- a/src-transpiler/expandType.mjs
+++ b/src-transpiler/expandType.mjs
@@ -77,6 +77,7 @@ function toSourceTS(node) {
     TypeOperator,    // parseType('keyof typeof obj')
     KeyOfKeyword, // "operator" key in TypeOperator node
     ConstructorType, // parseType('new (...args: any[]) => any');
+    NamedTupleMember,
   } = ts.SyntaxKind;
   // console.log({typeArguments, typeName, kind_, node});
   switch (node.kind) {
@@ -168,6 +169,8 @@ function toSourceTS(node) {
       return node.getText();
     case NumberKeyword:
       return node.getText();
+    case NamedTupleMember:
+      return toSourceTS(node.type);
     case IntersectionType:
       return {
         type: 'intersection',

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -84,6 +84,10 @@
     "output": "./test/typechecking/simple-ObjectPattern-output.mjs"
   },
   {
+    "input": "./test/typechecking/tuple-named-input.mjs",
+    "output": "./test/typechecking/tuple-named-output.mjs"
+  },
+  {
     "input": "./test/typechecking/typedef-BigIntKeyword-input.mjs",
     "output": "./test/typechecking/typedef-BigIntKeyword-output.mjs"
   },

--- a/test/typechecking/tuple-named-input.mjs
+++ b/test/typechecking/tuple-named-input.mjs
@@ -1,0 +1,5 @@
+/**
+ * Named tuple to indicate the order we are using is (height x width), even though
+ * the Graphics’ industry standard is (width x height).
+ * @typedef {[height: number, width: number]} HeightWidth
+ */

--- a/test/typechecking/tuple-named-output.mjs
+++ b/test/typechecking/tuple-named-output.mjs
@@ -1,0 +1,7 @@
+registerTypedef('HeightWidth', {
+  "type": "tuple",
+  "elements": [
+    "number",
+    "number"
+  ]
+});


### PR DESCRIPTION
Fixes: #87 

Input:

```js
/**
 * Named tuple to indicate the order we are using is (height x width), even though
 * the Graphics’ industry standard is (width x height).
 * @typedef {[height: number, width: number]} HeightWidth
 */

```

Generated output:

```js
registerTypedef('HeightWidth', {
  "type": "tuple",
  "elements": [
    "number",
    "number"
  ]
});

```