### PR TITLE
Add npmhelper.js to publish all packages quicker

### DIFF
--- a/@runtime-type-inspector/runtime/package.json
+++ b/@runtime-type-inspector/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtime-type-inspector/runtime",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Validating JSDoc types at runtime for high-quality types - Trust is good, control is better.",
   "main": "index.cjs",
   "module": "index.mjs",
@@ -21,6 +21,6 @@
     "index.mjs"
   ],
   "dependencies": {
-    "display-anything": "^1.1.0"
+    "display-anything": "^1.2.0"
   }
 }

--- a/@runtime-type-inspector/transpiler/package.json
+++ b/@runtime-type-inspector/transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtime-type-inspector/transpiler",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Validating JSDoc types at runtime for high-quality types - Trust is good, control is better.",
   "main": "index.cjs",
   "module": "index.mjs",
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/kungfooman/RuntimeTypeInspector.js#readme",
   "dependencies": {
     "@babel/parser": "^7.23.0",
-    "@runtime-type-inspector/runtime": "~3.1.0",
+    "@runtime-type-inspector/runtime": "^3.2.0",
     "typescript": "^5.1.6"
   },
   "files": [

--- a/npmhelper.js
+++ b/npmhelper.js
@@ -1,4 +1,4 @@
-import {readFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'fs';
 import {execSync} from 'child_process';
 /*
 cd plugin-parcel1 && npm publish
@@ -13,24 +13,45 @@ cd plugin-webpack5 && npm publish
 cd ..
 */
 const dirs = [
-    '@runtime-type-inspector/runtime',
-    '@runtime-type-inspector/transpiler',
-    'plugin-parcel1',
-    'plugin-parcel2',
-    'plugin-rollup',
-    'plugin-webpack4',
-    'plugin-webpack5',
+  '@runtime-type-inspector/runtime',
+  '@runtime-type-inspector/transpiler',
+  'plugin-parcel1',
+  'plugin-parcel2',
+  'plugin-rollup',
+  'plugin-webpack4',
+  'plugin-webpack5',
 ];
+const newVersion = '3.2.0';
 for (const dir of dirs) {
-    const file = `${dir}/package.json`;
-    const command = [
-        `cd ${dir}`,
-        'npm publish'
-    ].join(' && ');
-    //console.log(`# Package: ${dir}`);
-    //console.log(command);
-    //execSync(command);
-    const content = readFileSync(file, 'utf8');
-    const json = JSON.parse(content);
-    console.log(`Publish ${json.name}@${json.version}`);
+  const file = `${dir}/package.json`;
+  const command = [
+    `cd ${dir}`,
+    'npm publish'
+  ].join(' && ');
+  //console.log(`# Package: ${dir}`);
+  //console.log(command);
+  //execSync(command);
+  const content = readFileSync(file, 'utf8');
+  const json = JSON.parse(content);
+  json.version = newVersion;
+  for (const key in json.dependencies) {
+    if (key.includes('runtime-type-inspector')) {
+      json.dependencies[key] = `^${newVersion}`;
+    }
+  }
+  const newContent = JSON.stringify(json, null, 2) + '\n';
+  writeFileSync(file, newContent);
+}
+for (const dir of dirs) {
+  const command = [
+    `cd ${dir}`,
+    'npm publish',
+  ].join(' && ') + '\ncd ..';
+  console.log(command);
+}
+for (const dir of dirs) {
+  const file = `${dir}/package.json`;
+  const content = readFileSync(file, 'utf8');
+  const json = JSON.parse(content);
+  console.log(`Publish ${json.name}@${json.version}`);
 }

--- a/npmhelper.js
+++ b/npmhelper.js
@@ -18,8 +18,10 @@ const dirs = [
   'plugin-parcel1',
   'plugin-parcel2',
   'plugin-rollup',
+  'plugin-webpack',
   'plugin-webpack4',
   'plugin-webpack5',
+  'repl',
 ];
 const newVersion = '3.2.0';
 for (const dir of dirs) {

--- a/plugin-parcel1/package.json
+++ b/plugin-parcel1/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@runtime-type-inspector/plugin-parcel1",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "RuntimeTypeInspector.js plugin for Parcel v1",
   "main": "index.cjs",
-  "publishConfig": {"access": "public"},
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "commonjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
     "parcel-bundler": "^1.12.5",
-    "@runtime-type-inspector/transpiler": "^3.1.0"
+    "@runtime-type-inspector/transpiler": "^3.2.0"
   }
 }

--- a/plugin-parcel2/package.json
+++ b/plugin-parcel2/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@runtime-type-inspector/parcel-transformer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "RuntimeTypeInspector.js plugin for Parcel v2",
   "main": "index.mjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
     "@parcel/plugin": "^2.10.1",
-    "@runtime-type-inspector/transpiler": "^3.1.0"
+    "@runtime-type-inspector/transpiler": "^3.2.0"
   },
   "engines": {
     "parcel": "2.x"

--- a/plugin-rollup/package.json
+++ b/plugin-rollup/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@runtime-type-inspector/plugin-rollup",
   "type": "module",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Rollup plugin for https://runtimetypeinspector.org/",
   "main": "index.mjs",
   "types": "index.mjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
-    "@runtime-type-inspector/transpiler": "~3.1.0",
+    "@runtime-type-inspector/transpiler": "^3.2.0",
     "rollup": "^3.29.4"
   }
 }

--- a/plugin-webpack/package.json
+++ b/plugin-webpack/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@runtime-type-inspector/plugin-webpack",
-  "version": "1.0.0",
+  "version": "3.2.0",
   "description": "Webpack plugin for https://runtimetypeinspector.org/",
   "main": "index.cjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
-    "@runtime-type-inspector/plugin-webpack4": "latest",
-    "@runtime-type-inspector/plugin-webpack5": "latest"
+    "@runtime-type-inspector/plugin-webpack4": "^3.2.0",
+    "@runtime-type-inspector/plugin-webpack5": "^3.2.0"
   }
 }

--- a/plugin-webpack4/package.json
+++ b/plugin-webpack4/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@runtime-type-inspector/plugin-webpack4",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Webpack 4 plugin for https://runtimetypeinspector.org/",
   "main": "index.cjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
-    "@runtime-type-inspector/transpiler": "^3.1.0",
+    "@runtime-type-inspector/transpiler": "^3.2.0",
     "loader-utils": "^2.0.4",
     "webpack": "^4.47.0"
   }

--- a/plugin-webpack5/package.json
+++ b/plugin-webpack5/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@runtime-type-inspector/plugin-webpack5",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Webpack 5 plugin for https://runtimetypeinspector.org/",
   "main": "index.cjs",
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "dependencies": {
-    "@runtime-type-inspector/transpiler": "~3.1.0",
+    "@runtime-type-inspector/transpiler": "^3.2.0",
     "loader-utils": "^2.0.4",
     "webpack": "^5.89.0"
   }

--- a/repl/package.json
+++ b/repl/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@runtime-type-inspector/repl",
-  "version": "1.0.2",
+  "version": "3.2.0",
   "description": "REPL of RuntimeTypeInspector.js",
   "main": "index.html",
-  "dependencies": {
-    "@runtime-type-inspector/transpiler": "^3.0.8",
-    "ace-builds": "^1.28.0",
-    "display-anything": "^1.1.0",
-    "express": "^4.18.2"
-  },
   "author": "Hermann Rolfes (kungfooman)",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@runtime-type-inspector/transpiler": "^3.2.0",
+    "ace-builds": "^1.28.0",
+    "display-anything": "^1.1.0",
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
Fixes: #131

Currently outputs:

```sh
cd @runtime-type-inspector/runtime && npm publish
cd ..
cd @runtime-type-inspector/transpiler && npm publish
cd ..
cd plugin-parcel1 && npm publish
cd ..
cd plugin-parcel2 && npm publish
cd ..
cd plugin-rollup && npm publish
cd ..
cd plugin-webpack4 && npm publish
cd ..
cd plugin-webpack5 && npm publish
cd ..
Publish @runtime-type-inspector/runtime@3.2.0
Publish @runtime-type-inspector/transpiler@3.2.0
Publish @runtime-type-inspector/plugin-parcel1@3.2.0
Publish @runtime-type-inspector/parcel-transformer@3.2.0
Publish @runtime-type-inspector/plugin-rollup@3.2.0
Publish @runtime-type-inspector/plugin-webpack4@3.2.0
Publish @runtime-type-inspector/plugin-webpack5@3.2.0
```

The first half is good for auto-publishing and the second half is a good `git commit` message.