### PR TITLE
Add `validationDivision` errors in UI

### DIFF
--- a/repl/index.js
+++ b/repl/index.js
@@ -275,7 +275,9 @@ function actionJSDoc() {
   setRight(out);
 }
 function actionTypeChecking() {
-  setRight(addTypeChecks(getLeft(), {expandType: getPreferredExpandType()}));
+  const expandType = getPreferredExpandType();
+  const filename = 'repl.js';
+  setRight(addTypeChecks(getLeft(), {expandType, filename}));
 }
 /**
  * @todo use Monaco Diff Editor

--- a/src-runtime/validateDivision.js
+++ b/src-runtime/validateDivision.js
@@ -1,31 +1,60 @@
+import {Warning    } from "./Warning.js";
+import {options    } from "./options.js";
+import {warnedTable} from "./warnedTable.js";
+/**
+ * @param {*} value - The actual value that we need to validate.
+ * @param {*} expect - The supposed type information of said value.
+ * @param {string} loc - Using this.filename if division is in global context.
+ * @param {string} name - Not a function argument name anymore, we need it
+ * anyway for key generation (for state saving/loading)
+ * @param {string} msg - The message.
+ * @param {object} details - Object with some local details for quick devtools checking.
+ */
+function validateDivisionAddWarning(value, expect, loc, name, msg, details) {
+  const key = `${loc}-${name}`;
+  let warnObj = options.warned[key];
+  if (!warnObj) {
+    warnObj = new Warning(msg, value, expect, loc, name);
+    warnedTable?.append(warnObj.tr);
+    options.warned[key] = warnObj;
+  }
+  warnObj.hits++;
+  warnObj.warn(msg, details);
+  warnObj.value = value;
+}
 /**
  * @todo Fix transpiler to include loc/name for divisions and use warn system connected to UI.
  * @param {number} lhs - The left hand side.
  * @param {number} rhs - The right hand side.
+ * @param {string} loc - Location of division.
  * @example
  * validateDivision( 1 ,  2 ); // Outputs: 0.5
  * validateDivision( 1 , "2"); // Warns: validateDivision> incompatible type pair
  * validateDivision(10n,  2n); // Outputs: 5n
  * @returns {number} The division result.
  */
-function validateDivision(lhs, rhs) {
+function validateDivision(lhs, rhs, loc = 'unspecified') {
   const ret = lhs / rhs;
   const twoNumbers = typeof lhs === 'number' && typeof rhs === 'number';
   const twoBigInts = typeof lhs === 'bigint' && typeof rhs === 'bigint';
   const valid = twoNumbers || twoBigInts;
   if (!valid) {
-    console.warn(`validateDivision> incompatible type pair`, {lhs, rhs, twoNumbers, twoBigInts});
+    const expect = {type: 'union', members: ['number', 'bigint']};
+    const msg = `validateDivision> incompatible type pair`;
+    const details = {lhs, rhs, twoNumbers, twoBigInts};
+    validateDivisionAddWarning(ret, expect, loc, 'division', msg, details);
   }
   // If we got two bigint's, we are done, as isNaN and isFinite is only for "normal" numbers.
   if (twoBigInts) {
     return ret;
   }
   if (isNaN(ret)) {
-    console.warn(`validateDivision> NaN`, {lhs, rhs});
+    validateDivisionAddWarning(ret, 'number', loc, 'division', `validateDivision> NaN`, {lhs, rhs});
   }
   if (!isFinite(ret)) {
-    console.warn(`validateDivision> +-Infinity`, {lhs, rhs});
+    const msg = `validateDivision> +-Infinity`;
+    validateDivisionAddWarning(ret, 'number', loc, 'division', msg, {lhs, rhs});
   }
   return ret;
 }
-export {validateDivision};
+export {validateDivisionAddWarning, validateDivision};

--- a/src-runtime/validateDivision.js
+++ b/src-runtime/validateDivision.js
@@ -23,7 +23,6 @@ function validateDivisionAddWarning(value, expect, loc, name, msg, details) {
   warnObj.value = value;
 }
 /**
- * @todo Fix transpiler to include loc/name for divisions and use warn system connected to UI.
  * @param {number} lhs - The left hand side.
  * @param {number} rhs - The right hand side.
  * @param {string} loc - Location of division.
@@ -34,7 +33,6 @@ function validateDivisionAddWarning(value, expect, loc, name, msg, details) {
  * @returns {number} The division result.
  */
 function validateDivision(lhs, rhs, loc = 'unspecified') {
-  const ret = lhs / rhs;
   const twoNumbers = typeof lhs === 'number' && typeof rhs === 'number';
   const twoBigInts = typeof lhs === 'bigint' && typeof rhs === 'bigint';
   const valid = twoNumbers || twoBigInts;
@@ -42,8 +40,9 @@ function validateDivision(lhs, rhs, loc = 'unspecified') {
     const expect = {type: 'union', members: ['number', 'bigint']};
     const msg = `validateDivision> incompatible type pair`;
     const details = {lhs, rhs, twoNumbers, twoBigInts};
-    validateDivisionAddWarning(ret, expect, loc, 'division', msg, details);
+    validateDivisionAddWarning('would throw', expect, loc, 'division', msg, details);
   }
+  const ret = lhs / rhs;
   // If we got two bigint's, we are done, as isNaN and isFinite is only for "normal" numbers.
   if (twoBigInts) {
     return ret;

--- a/src-transpiler/Asserter.js
+++ b/src-transpiler/Asserter.js
@@ -568,10 +568,18 @@ class Asserter extends Stringifier {
         return 'getName> missing parent for ' + node.type;
       case 'ObjectMethod':
         return toSource(key);
-      default:
-        this.warn('getName> unhandled type', type, 'for', node);
-        return '/*MISSING*/';
+      case 'BinaryExpression':
+        const goodNames = ['FunctionDeclaration', 'ClassMethod', 'ClassPrivateMethod'];
+        const goodParent = this.parents.findLast(_ => goodNames.includes(_.type));
+        if (goodParent) {
+          return this.getName(goodParent);
+        }
+        // top scope
+        return `${this.filename}:${node?.loc?.start?.line}`;
     }
+    this.warn('getName> unhandled type', type, 'for', node, this.path);
+    //debugger;
+    return `${this.filename}:${node?.loc?.start?.line}`;
   }
   /**
    * @override
@@ -586,7 +594,8 @@ class Asserter extends Stringifier {
     const left_ = this.toSource(left);
     const right_ = this.toSource(right);
     if (operator === '/') {
-      return `validateDivision(${left_}, ${right_})`;
+      const loc = this.getName(node);
+      return `validateDivision(${left_}, ${right_}, ${JSON.stringify(loc)})`;
     }
     return `${left_} ${operator} ${right_}`;
   }

--- a/src-transpiler/Stringifier.js
+++ b/src-transpiler/Stringifier.js
@@ -263,10 +263,12 @@ class Stringifier {
   get spaces() {
     return '  '.repeat(this.numSpaces);
   }
+  get path() {
+    return this.parents.map(_ => _.type).join('/');
+  }
   debugSpaces() {
-    const {spaces, parents} = this;
+    const {spaces, path} = this;
     const n = spaces.length;
-    const path = parents.map(_ => _.type).join('/');
     return `${spaces}// got ${n} spaces for ${path}\n`;
   }
   /**

--- a/test.js
+++ b/test.js
@@ -46,7 +46,11 @@ function normalize(input) {
 for (const {input, output} of tests) {
   const inputContent = readFileSync(input, 'utf8');
   const outputContent = readFileSync(output, 'utf8');
-  const newOutputContent = addTypeChecks(inputContent, {expandType, addHeader: false});
+  const newOutputContent = addTypeChecks(inputContent, {
+    expandType,
+    addHeader: false,
+    filename: 'repl.js'
+  });
   if (normalize(newOutputContent) !== normalize(outputContent)) {
     discrepancies++;
     console.error("Discrepancy detected, please check!", {

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -118,5 +118,17 @@
   {
     "input": "./test/typechecking/typedef-promise-input.mjs",
     "output": "./test/typechecking/typedef-promise-output.mjs"
+  },
+  {
+    "input": "./test/typechecking/validateDivision-class-input.mjs",
+    "output": "./test/typechecking/validateDivision-class-output.mjs"
+  },
+  {
+    "input": "./test/typechecking/validateDivision-function-input.mjs",
+    "output": "./test/typechecking/validateDivision-function-output.mjs"
+  },
+  {
+    "input": "./test/typechecking/validateDivision-top-input.mjs",
+    "output": "./test/typechecking/validateDivision-top-output.mjs"
   }
 ]

--- a/test/typechecking/validateDivision-class-input.mjs
+++ b/test/typechecking/validateDivision-class-input.mjs
@@ -1,0 +1,5 @@
+class Test {
+  test() {
+    return 123 / 0;
+  }
+}

--- a/test/typechecking/validateDivision-class-output.mjs
+++ b/test/typechecking/validateDivision-class-output.mjs
@@ -1,0 +1,6 @@
+class Test {
+  test() {
+    return validateDivision(123, 0, "Test#test");
+  }
+}
+registerClass(Test);

--- a/test/typechecking/validateDivision-function-input.mjs
+++ b/test/typechecking/validateDivision-function-input.mjs
@@ -1,0 +1,3 @@
+function test() {
+  return 123 / 0;
+}

--- a/test/typechecking/validateDivision-function-output.mjs
+++ b/test/typechecking/validateDivision-function-output.mjs
@@ -1,0 +1,3 @@
+function test() {
+  return validateDivision(123, 0, "test");
+}

--- a/test/typechecking/validateDivision-top-input.mjs
+++ b/test/typechecking/validateDivision-top-input.mjs
@@ -1,0 +1,1 @@
+console.log("ret", 123 / 0);

--- a/test/typechecking/validateDivision-top-output.mjs
+++ b/test/typechecking/validateDivision-top-output.mjs
@@ -1,0 +1,1 @@
+console.log("ret", validateDivision(123, 0, "repl.js:1"));


### PR DESCRIPTION
Fixes: #147 

The division errors in UI looks like this:

![image](https://github.com/kungfooman/RuntimeTypeInspector.js/assets/5236548/36449b38-28a4-4f86-a61a-4219e562643d)

If there is more context available, we use it:

```js
function test() {
  console.log("ret", 123 / 0);
}
test();
```

![image](https://github.com/kungfooman/RuntimeTypeInspector.js/assets/5236548/e963c470-8d82-45a5-b22e-d0de94fae40e)

The `name` row doesn't make too much sense - it's an artifact of only checking function arguments from the beginning and a division isn't exactly a function with argument names (I guess we could call it dividor in case of `123 / 0`, but we also check for bigint/number incompatibility e.g.)