### PR TITLE
src-transpiler/expandType.js: serialize IndexSignature

### DIFF
--- a/src-transpiler/expandType.js
+++ b/src-transpiler/expandType.js
@@ -298,7 +298,7 @@ function toSourceTS(node) {
         }
       });
       const ret = {type: 'object'};
-      if (properties) {
+      if (Object.keys(properties).length) {
         ret.properties = properties;
       }
       if (indexSignatures) {

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -24,6 +24,14 @@
     "output": "./test/typechecking/ExportNamespaceSpecifier-output.mjs"
   },
   {
+    "input": "./test/typechecking/IndexSignature-1-input.mjs",
+    "output": "./test/typechecking/IndexSignature-1-output.mjs"
+  },
+  {
+    "input": "./test/typechecking/IndexSignature-2-input.mjs",
+    "output": "./test/typechecking/IndexSignature-2-output.mjs"
+  },
+  {
     "input": "./test/typechecking/JSDoc-FunctionExpression-ExpressionStatement-input.mjs",
     "output": "./test/typechecking/JSDoc-FunctionExpression-ExpressionStatement-output.mjs"
   },

--- a/test/typechecking/IndexSignature-1-input.mjs
+++ b/test/typechecking/IndexSignature-1-input.mjs
@@ -1,0 +1,14 @@
+/**
+ * @param {{[n: number]: string, length: number}} words
+ */
+function countWords(words) {
+  return words.length;
+}
+countWords({
+  0: 'Hello',
+  1: ' ',
+  2: 'World',
+  3: '!',
+  length: 4
+});
+countWords(['Hello', ' ', 'World', '!']);

--- a/test/typechecking/IndexSignature-1-output.mjs
+++ b/test/typechecking/IndexSignature-1-output.mjs
@@ -1,0 +1,35 @@
+/**
+ * @param {{[n: number]: string, length: number}} words
+ */
+function countWords(words) {
+  if (!inspectType(words, {
+    "type": "object",
+    "properties": {
+      "length": "number"
+    },
+    "indexSignatures": [
+      {
+        "type": "indexSignature",
+        "indexType": "string",
+        "indexParameters": [
+          {
+            "type": "number",
+            "name": "n"
+          }
+        ]
+      }
+    ],
+    "optional": false
+  }, 'countWords', 'words')) {
+    youCanAddABreakpointHere();
+  }
+  return words.length;
+}
+countWords({
+  0: 'Hello',
+  1: ' ',
+  2: 'World',
+  3: '!',
+  length: 4
+});
+countWords(['Hello', ' ', 'World', '!']);

--- a/test/typechecking/IndexSignature-2-input.mjs
+++ b/test/typechecking/IndexSignature-2-input.mjs
@@ -1,0 +1,34 @@
+/**
+ * @typedef {{[n: number]: boolean}} Arrayish
+ * @typedef {{[k: string]: boolean}} Mapish
+ */
+/**
+ * @param {Arrayish} arrayish - Arrayish.
+ */
+function takeArrayish(arrayish) {
+  // Nothing yet.
+}
+/**
+ * @param {Mapish} mapish - Mapish.
+ */
+function takeMapish(mapish) {
+  // Nothing yet.
+}
+takeArrayish({
+  0: true,
+  1: false,
+});
+takeArrayish({
+  0: "1st error"
+});
+takeArrayish({
+  "0": "2nd error",
+});
+takeArrayish({
+  "0": "3rd and 4th error",
+});
+takeMapish({
+  'a': true,
+  'b': false,
+  'c': "trigger",
+});

--- a/test/typechecking/IndexSignature-2-output.mjs
+++ b/test/typechecking/IndexSignature-2-output.mjs
@@ -1,0 +1,68 @@
+registerTypedef('Arrayish', {
+  "type": "object",
+  "indexSignatures": [
+    {
+      "type": "indexSignature",
+      "indexType": "boolean",
+      "indexParameters": [
+        {
+          "type": "number",
+          "name": "n"
+        }
+      ]
+    }
+  ]
+});
+registerTypedef('Mapish', {
+  "type": "object",
+  "indexSignatures": [
+    {
+      "type": "indexSignature",
+      "indexType": "boolean",
+      "indexParameters": [
+        {
+          "type": "string",
+          "name": "k"
+        }
+      ]
+    }
+  ]
+});
+/**
+ * @typedef {{[n: number]: boolean}} Arrayish
+ * @typedef {{[k: string]: boolean}} Mapish
+ */
+/**
+ * @param {Arrayish} arrayish - Arrayish.
+ */
+function takeArrayish(arrayish) {
+  if (!inspectType(arrayish, "Arrayish", 'takeArrayish', 'arrayish')) {
+    youCanAddABreakpointHere();
+  }
+}
+/**
+ * @param {Mapish} mapish - Mapish.
+ */
+function takeMapish(mapish) {
+  if (!inspectType(mapish, "Mapish", 'takeMapish', 'mapish')) {
+    youCanAddABreakpointHere();
+  }
+}
+takeArrayish({
+  0: true,
+  1: false,
+});
+takeArrayish({
+  0: "1st error"
+});
+takeArrayish({
+  "0": "2nd error",
+});
+takeArrayish({
+  "0": "3rd and 4th error",
+});
+takeMapish({
+  'a': true,
+  'b': false,
+  'c': "trigger",
+});


### PR DESCRIPTION
Fixes: #155

This allows to structurize types like this:

```js
/**
 * @param {{[n: number]: string, length: number}} words
 */
function countWords(words) {
  return words.length;
}
countWords({
  0: 'Hello',
  1: ' ',
  2: 'World',
  3: '!',
  length: 4
});
countWords(['Hello', ' ', 'World', '!']);

```

Into this:

```js
/**
 * @param {{[n: number]: string, length: number}} words
 */
function countWords(words) {
  if (!inspectType(words, {
    "type": "object",
    "properties": {
      "length": "number"
    },
    "indexSignatures": [
      {
        "type": "indexSignature",
        "indexType": "string",
        "indexParameters": [
          {
            "type": "number",
            "name": "n"
          }
        ]
      }
    ],
    "optional": false
  }, 'countWords', 'words')) {
    youCanAddABreakpointHere();
  }
  return words.length;
}
```

The validation will happen in another PR...