### PR TITLE
Remove useless warning from getters with JSDoc description

### DIFF
--- a/src-transpiler/Asserter.js
+++ b/src-transpiler/Asserter.js
@@ -273,17 +273,22 @@ class Asserter extends Stringifier {
     if (node.type === 'BlockStatement') {
       node = this.parent;
     }
-    if (node.type === 'ClassMethod' && node.kind === 'set') {
-      const paramName = this.getNameOfParam(node.params[0]);
-      if (node.params.length !== 1) {
-        this.warn("getJSDoc> setters require exactly one argument");
-      }
-      const setterType = parseJSDocSetter(comment, this.expandType);
-      if (!setterType) {
+    if (node.type === 'ClassMethod') {
+      if (node.kind === 'get') {
+        // JSDoc on a getter is just some documentation.
         return;
+      } else if (node.kind === 'set') {
+        if (node.params.length !== 1) {
+          this.warn("getJSDoc> setters require exactly one argument");
+        }
+        const setterType = parseJSDocSetter(comment, this.expandType);
+        if (!setterType) {
+          return;
+        }
+        const paramName = this.getNameOfParam(node.params[0]);
+        const params    = {[paramName]: setterType};
+        return {templates: undefined, params};
       }
-      const params = {[paramName]: setterType};
-      return {templates: undefined, params};
     }
     const templates = parseJSDocTemplates(comment);
     const params = parseJSDoc(comment, this.expandType);

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -80,6 +80,10 @@
     "output": "./test/typechecking/literal-numbers-output.mjs"
   },
   {
+    "input": "./test/typechecking/setter-no-type-getter-no-type-input.mjs",
+    "output": "./test/typechecking/setter-no-type-getter-no-type-output.mjs"
+  },
+  {
     "input": "./test/typechecking/setter-no-type-input.mjs",
     "output": "./test/typechecking/setter-no-type-output.mjs"
   },

--- a/test/typechecking/setter-no-type-getter-no-type-input.mjs
+++ b/test/typechecking/setter-no-type-getter-no-type-input.mjs
@@ -1,0 +1,19 @@
+class Test {
+  _abc = 123;
+  /**
+   * Only description for getter.
+   */
+  get abc() {
+    return this._abc;
+  }
+  /**
+   * Only description for setter.
+   */
+  set abc(val) {
+    this._abc = val;
+  }
+}
+const test = new Test();
+console.log(test.abc);
+test.abc = 1;
+console.log(test.abc);

--- a/test/typechecking/setter-no-type-getter-no-type-output.mjs
+++ b/test/typechecking/setter-no-type-getter-no-type-output.mjs
@@ -1,0 +1,20 @@
+class Test {
+  _abc = 123;
+  /**
+   * Only description for getter.
+   */
+  get abc() {
+    return this._abc;
+  }
+  /**
+   * Only description for setter.
+   */
+  set abc(val) {
+    this._abc = val;
+  }
+}
+registerClass(Test);
+const test = new Test();
+console.log(test.abc);
+test.abc = 1;
+console.log(test.abc);


### PR DESCRIPTION
Fixes: #161