### PR TITLE
TypePanel: Add button for clearing all previous warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,7 @@ module.exports = {
     "no-dupe-else-if": "error",
     "no-dupe-keys": "error",
     "no-duplicate-case": "error",
-    // "no-duplicate-imports": "error",
+    "no-duplicate-imports": "off",
     "no-empty-character-class": "error",
     "no-empty-pattern": "error",
     "no-ex-assign": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -395,7 +395,7 @@ module.exports = {
 
     // Style guide
     "import/extensions": ["error", "always", {"ts": "never", "tsx": "never"}],
-    "import/no-duplicates": "warn",
+    "import/no-duplicates": "off",
 
     // JSDoc rules
     "jsdoc/check-access": "error",

--- a/src-runtime/TypePanel.js
+++ b/src-runtime/TypePanel.js
@@ -57,8 +57,12 @@ class TypePanel {
   buttonHide      = document.createElement('button');
   buttonLoadState = document.createElement('button');
   buttonSaveState = document.createElement('button');
+  buttonClear     = document.createElement('button');
   constructor() {
-    const {div, inputEnable, spanErrors, span, select, option_spam, option_once, option_never, buttonHide, buttonLoadState, buttonSaveState} = this;
+    const {
+      div, inputEnable, spanErrors, span, select, option_spam, option_once, option_never,
+      buttonHide, buttonLoadState, buttonSaveState, buttonClear
+    } = this;
     div.style.position = "absolute";
     div.style.bottom = "0px";
     div.style.right = "0px";
@@ -100,7 +104,9 @@ class TypePanel {
     buttonLoadState.onclick = () => this.loadState();
     buttonSaveState.textContent = 'Save state';
     buttonSaveState.onclick = () => this.saveState();
-    div.append(inputEnable, spanErrors, span, select, buttonHide, buttonLoadState, buttonSaveState, warnedTable);
+    buttonClear.textContent = 'Clear';
+    buttonClear.onclick = () => this.clear();
+    div.append(inputEnable, spanErrors, span, select, buttonHide, buttonLoadState, buttonSaveState, buttonClear, warnedTable);
     div.style.maxHeight = '200px';
     div.style.overflow = 'scroll';
     const finalFunc = () => document.body.append(div);
@@ -112,6 +118,14 @@ class TypePanel {
       document.addEventListener("DOMContentLoaded", finalFunc);
     }
     this.loadState();
+  }
+  clear() {
+    const {warned} = options;
+    for (const key in warned) {
+      const warning = warned[key];
+      warning.tr.remove();
+      delete warned[key];
+    }
   }
   get state() {
     /** @type {object[]} */


### PR DESCRIPTION
Fixes: #149 

New button looks like this:

![image](https://github.com/kungfooman/RuntimeTypeInspector.js/assets/5236548/ff089b3e-2b97-4868-86dd-6594c743f776)
