### PR TITLE
JSDoc parsing: Improve `@param` end detection for special cases

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -355,11 +355,7 @@ module.exports = {
       }
     ],
     //"space-in-parens": ["error", "never"],
-    "space-infix-ops": [
-      "error", {
-        "int32Hint": false
-      }
-    ],
+    "space-infix-ops": "off",
     "space-unary-ops": [
       "error", {
         "words": true,

--- a/src-transpiler/parseJSDoc.js
+++ b/src-transpiler/parseJSDoc.js
@@ -28,10 +28,22 @@ function parseJSDoc(src, expandType = expandTypeDepFree) {
     //   name: [kwargs={}] The configuration parameters.
     //   name: [d = 1.0] Sample spacing
     if (name[0] === '[') {
-      // Possible improvement: counting opening/closing brackets for perfect match
-      const closer = name.lastIndexOf(']');
+      // Counting opening/closing brackets for perfect match
+      let openCloseCount = 1;
+      let i = 1;
+      for (; i<name.length; i++) {
+        const c = name[i];
+        if (c === '[') {
+          openCloseCount++;
+        } else if (c === ']') {
+          openCloseCount--;
+        }
+        if (openCloseCount === 0) {
+          break;
+        }
+      }
       // Afterwards name will be: d = 1.0
-      name = name.substring(1, closer);
+      name = name.substring(1, i);
       // mark it for the type:
       optional = true;
     }

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -72,6 +72,10 @@
     "output": "./test/typechecking/good-old-es5-output.mjs"
   },
   {
+    "input": "./test/typechecking/jsdoc-param-end-detection-input.mjs",
+    "output": "./test/typechecking/jsdoc-param-end-detection-output.mjs"
+  },
+  {
     "input": "./test/typechecking/jsdoc-regexp-default-values-sci-input.mjs",
     "output": "./test/typechecking/jsdoc-regexp-default-values-sci-output.mjs"
   },

--- a/test/typechecking/jsdoc-param-end-detection-input.mjs
+++ b/test/typechecking/jsdoc-param-end-detection-input.mjs
@@ -1,0 +1,8 @@
+/**
+ * @param {number[]} [nodes] - Defaults to [].
+ */
+function test(nodes = []) {
+  return nodes;
+}
+const ret = test([1, 2, 3]);
+console.log('ret', ret);

--- a/test/typechecking/jsdoc-param-end-detection-output.mjs
+++ b/test/typechecking/jsdoc-param-end-detection-output.mjs
@@ -1,0 +1,15 @@
+/**
+ * @param {number[]} [nodes] - Defaults to [].
+ */
+function test(nodes = []) {
+  if (!inspectType(nodes, {
+    "type": "array",
+    "elementType": "number",
+    "optional": true
+  }, 'test', 'nodes')) {
+    youCanAddABreakpointHere();
+  }
+  return nodes;
+}
+const ret = test([1, 2, 3]);
+console.log('ret', ret);


### PR DESCRIPTION
Fixes: #183 