### PR TITLE
`Stringifier#ArrowFunctionExpression`: remove extra space when not needed

### DIFF
--- a/src-transpiler/Stringifier.js
+++ b/src-transpiler/Stringifier.js
@@ -538,7 +538,10 @@ class Stringifier {
       out += ' * ';
     }
     out += this.FunctionDeclarationParams(params);
-    out += ' => ';
+    out += ' =>';
+    if (body.type !== 'BlockStatement') {
+      out += ' ';
+    }
     out += this.toSource(body);
     return out;
   }

--- a/test.js
+++ b/test.js
@@ -5,6 +5,11 @@ import {Asserter     } from './src-transpiler/Asserter.js';
 import {Stringifier  } from './src-transpiler/Stringifier.js';
 import {parserOptions} from './src-transpiler/parserOptions.js';
 /**
+ * @typedef InputOutput
+ * @property {string} input
+ * @property {string} output
+ */
+/**
  * @param {string} a - Left source code.
  * @param {string} b - Right source code.
  */
@@ -27,10 +32,11 @@ function compareLineByLine(a, b) {
   console.log(t);
 }
 const content = readFileSync('./test/typechecking.json', 'utf8');
+/** @type {InputOutput[]} */
 const tests = JSON.parse(content);
 let discrepancies = 0;
 /**
- * @param {*} input - Source code to normalize.
+ * @param {string} input - Source code to normalize.
  * @returns {string} Normalized output.
  */
 function normalize(input) {
@@ -49,7 +55,8 @@ function normalize(input) {
 for (const {input, output} of tests) {
   const inputContent  = readFileSync(input, 'utf8');
   const outputContent = readFileSync(output, 'utf8');
-  const Converter = input.includes('jsx') ? Stringifier : Asserter;
+  const useStringifer = input.includes('stringifier-') || input.includes('jsx');
+  const Converter = useStringifer ? Stringifier : Asserter;
   const converter = new Converter({
     expandType,
     addHeader: input.includes('jsx'),

--- a/test/typechecking.json
+++ b/test/typechecking.json
@@ -148,6 +148,10 @@
     "output": "./test/typechecking/simple-ObjectPattern-typedef-output.mjs"
   },
   {
+    "input": "./test/typechecking/stringifier-ArrowFunctionExpression-spaces-input.mjs",
+    "output": "./test/typechecking/stringifier-ArrowFunctionExpression-spaces-output.mjs"
+  },
+  {
     "input": "./test/typechecking/template-types-1-input.mjs",
     "output": "./test/typechecking/template-types-1-output.mjs"
   },

--- a/test/typechecking/stringifier-ArrowFunctionExpression-spaces-input.mjs
+++ b/test/typechecking/stringifier-ArrowFunctionExpression-spaces-input.mjs
@@ -1,0 +1,4 @@
+const a = () => {
+  console.log("test");
+};
+const b = () => 123;

--- a/test/typechecking/stringifier-ArrowFunctionExpression-spaces-output.mjs
+++ b/test/typechecking/stringifier-ArrowFunctionExpression-spaces-output.mjs
@@ -1,0 +1,4 @@
+const a = () => {
+  console.log("test");
+};
+const b = () => 123;


### PR DESCRIPTION
Fixes: #192 