### PR TITLE
Add CSS class to RTI TypePanel

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -2,6 +2,12 @@
   <head>
     <script src="importmap.js"></script>
     <link rel="stylesheet" href="./node_modules/display-anything/src/DisplayAnything.css"></link>
+    <style>
+      .rti-all {
+        max-height: 200px;
+        overflow-y: scroll;
+      }
+    </style>
   </head>
   <body>
     <select id="action">

--- a/src-runtime/TypePanel.js
+++ b/src-runtime/TypePanel.js
@@ -75,6 +75,7 @@ class TypePanel {
     divAll.style.bottom = "0px";
     divAll.style.right = "0px";
     divAll.style.zIndex = "10";
+    divAll.classList.add('rti-all');
     niceDiv(div);
     inputEnable.checked = isEnabled();
     inputEnable.type = "checkbox";


### PR DESCRIPTION
Fixes: #202 

Also makes it contained in a 200px high container to prevent flooding of TypePanel's:

![image](https://github.com/user-attachments/assets/85577f4e-7ab7-4543-a555-c101fe8e63cd)
