### PR TITLE
Fix `DataCloneError`'s by preventing known unclonable values (will be…   … send as string instead)

### DIFF
--- a/src-runtime/inspectType.js
+++ b/src-runtime/inspectType.js
@@ -106,6 +106,11 @@ function inspectType(value, expect, loc, name, critical = true) {
       crossContextPostMessage({type: 'rti', action: 'deleteBreakpoint', destination: 'ui', key});
     }
     // Nytaralyxe: options.warns where each warn callback supports one system (node, div/dom etc.)
+    // Don't post something that can't be transmitted cross-context, so we just stringify it.
+    // See https://github.com/kungfooman/RuntimeTypeInspector.js/issues/223
+    if (value instanceof Function) {
+      value += "";
+    }
     crossContextPostMessage({type: 'rti', action: 'addError', destination: 'ui', value, expect, loc, name, valueToString, strings, extras, key});
   }
   return ret;

--- a/test/convert-first/test-typeof.js
+++ b/test/convert-first/test-typeof.js
@@ -19,7 +19,11 @@ class TestClass2 {
 function callNew(someClass, ...args) {
   return new someClass(...args);
 }
+options.count = 0;
 const testClass1 = callNew(TestClass1, "hoi1");
 console.assert(options.count === 0, "Should have 0 errors here");
 const testClass2 = callNew(TestClass2, "hoi2");
 console.assert(options.count === 1, "Should have 1 error here");
+if (options.count === 1) {
+  console.log("SUCCESS!");
+}


### PR DESCRIPTION
Fixes: #223 